### PR TITLE
Space Between utilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const borderRadiusUtilities = require('./borderRadiusUtilities');
 const borderWidthUtilities = require('./borderWidthUtilities');
 const textAlignUtilities = require('./textAlignUtilities');
 const transformOriginUtilities = require('./transformOriginUtilities');
+const spaceUtilities = require('./spaceUtilities');
 
 module.exports = plugin(function ({ addUtilities, e, theme, variants, target }) {
   addUtilities(paddingUtilities(theme, e, target), variants('padding'));
@@ -20,4 +21,5 @@ module.exports = plugin(function ({ addUtilities, e, theme, variants, target }) 
   addUtilities(borderWidthUtilities(theme, e, target), variants('borderWidth'));
   addUtilities(textAlignUtilities(), variants('textAlign'));
   addUtilities(transformOriginUtilities(), variants('transformOrigin'));
+  addUtilities(spaceUtilities(theme, e, target), variants('space'));
 });

--- a/spaceUtilities.js
+++ b/spaceUtilities.js
@@ -1,0 +1,31 @@
+const _ = require('lodash');
+const {
+  default: prefixNegativeModifiers,
+} = require('tailwindcss/lib/util/prefixNegativeModifiers');
+
+module.exports = (theme, e, target) => {
+  const generators = (target('space') === 'ie11') ?
+    [(size, modifier) => ({
+      [`[dir="ltr"] .${e( prefixNegativeModifiers('space-s', modifier))} > :not(template) ~ :not(template)`]: {
+        marginLeft: size,
+      },
+      [`[dir="rtl"] .${e( prefixNegativeModifiers('space-s', modifier))} > :not(template) ~ :not(template)`]: {
+        marginRight: size,
+      },
+    }),
+    ] : [(size, modifier) => ({
+        [`.${e(prefixNegativeModifiers('space-s', modifier))} > :not(template) ~ :not(template)`]: {
+          '--space-s-reverse': '0',
+          marginInlineEnd: `calc(${size === '0' ? '0px' : size} * var(--space-s-reverse))`,
+          marginInlineStart: `calc(${size === '0' ? '0px' : size} * calc(1 - var(--space-s-reverse)))`,
+        },
+      }),
+    ];
+
+  return (target('space') === 'ie11') ?
+    _.flatMap(generators, generator => _.flatMap(theme('space'), generator)) :
+    _.flatMap(generators, generator => [
+      ..._.flatMap(theme('space'), generator),
+      { '.space-s-reverse > :not(template) ~ :not(template)': { '--space-s-reverse': '1' } },
+    ]);
+};


### PR DESCRIPTION
[space](https://tailwindcss.com/docs/space) and [divide](hhttps://tailwindcss.com/docs/divide-width) layout utilities first introduced in v1.3, and they work only for LTR layouts.

Since their titles aren't direction-specific but their action is, adding them to this plugin could mess the inutility of it (replace left with right and right with left).

I have tried [changing it the TailwindCSS framework itself](https://github.com/tailwindlabs/tailwindcss/pull/1883) but this takes too long.

meanwhile, I have come up with an alternative

`space-x ---> space-s`