### PR TITLE
divide-width utility support

### DIFF
--- a/divideUtilities.js
+++ b/divideUtilities.js
@@ -1,0 +1,35 @@
+const _ = require('lodash');
+
+module.exports = (theme, e, target) => {
+  const generators = (target('space') === 'ie11') ?
+    [(size, modifier) => ({
+      [`[dir="ltr"] .${e(`divide-s${modifier}`)} > :not(template) ~ :not(template)`]: {
+        borderLeftWidth: size,
+      },
+      [`[dir="rtl"] .${e(`divide-s${modifier}`)} > :not(template) ~ :not(template)`]: {
+        borderRightWidth: size,
+      },
+    }),
+    ] : [(size, modifier) => ({
+      [`.${e(`divide-s${modifier}`)} > :not(template) ~ :not(template)`]: {
+        '--divide-s-reverse': '0',
+        borderInlineEndWidth: `calc(${size === '0' ? '0px' : size} * var(--divide-s-reverse))`,
+        borderInlineStartWidth: `calc(${size === '0' ? '0px' : size} * calc(1 - var(--divide-s-reverse)))`,
+      },
+    }),
+    ];
+
+  return (target('space') === 'ie11') ?
+    _.flatMap(generators, generator => {
+      return _.flatMap(theme('divideWidth'), (value, modifier) => {
+        return generator(value, modifier === 'default' ? '' : `-${modifier}`);
+      });
+    }) :
+    _.flatMap(generators, generator => [
+      ..._.flatMap(theme('divideWidth'), (value, modifier) => {
+        return generator(value, modifier === 'default' ? '' : `-${modifier}`);
+      }), {
+        '.divide-s-reverse > :not(template) ~ :not(template)': { '--divide-s-reverse': '1' },
+      },
+    ]);
+};

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const borderWidthUtilities = require('./borderWidthUtilities');
 const textAlignUtilities = require('./textAlignUtilities');
 const transformOriginUtilities = require('./transformOriginUtilities');
 const spaceUtilities = require('./spaceUtilities');
+const divideUtilities = require('./divideUtilities');
 
 module.exports = plugin(function ({ addUtilities, e, theme, variants, target }) {
   addUtilities(paddingUtilities(theme, e, target), variants('padding'));
@@ -22,4 +23,5 @@ module.exports = plugin(function ({ addUtilities, e, theme, variants, target }) 
   addUtilities(textAlignUtilities(), variants('textAlign'));
   addUtilities(transformOriginUtilities(), variants('transformOrigin'));
   addUtilities(spaceUtilities(theme, e, target), variants('space'));
+  addUtilities(divideUtilities(theme, e, target), variants('divide'));
 });


### PR DESCRIPTION
[divide-width](https://tailwindcss.com/docs/divide-width) wasn't supported in RTL layouts, the utility `divide-s` will be used instead of `divide-x` and will support both RTL and LTR layouts.